### PR TITLE
AI: rework if_can_faint into three macros

### DIFF
--- a/asm/macros/battle_ai_script.inc
+++ b/asm/macros/battle_ai_script.inc
@@ -357,9 +357,10 @@
 	.4byte \param3
 	.endm
 
-	.macro if_can_faint param0:req
+	.macro if_can_faint_with_threshold param0:req ptr:req
 	.byte 0x3d
-	.4byte \param0
+	.byte \param0
+	.4byte \ptr
 	.endm
 
 	.macro if_cant_faint param0:req
@@ -924,3 +925,15 @@
     goto \param2
     .AI_item_is_actually_held_\@:
     .endm
+
+	  .macro if_can_faint ptr:req
+    if_can_faint_with_threshold AI_FAINT_THRESHOLD_RANDOM, \ptr
+	  .endm
+
+	  .macro if_will_faint ptr:req
+    if_can_faint_with_threshold AI_FAINT_THRESHOLD_PESSIMISTIC, \ptr
+	  .endm
+
+	  .macro if_has_some_chance_to_faint ptr:req
+    if_can_faint_with_threshold AI_FAINT_THRESHOLD_OPTIMISTIC, \ptr
+	  .endm

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -47,6 +47,11 @@
 
 #define AI_NHKO_PESSIMISTIC 4
 
+// if_can_faint_with_threshold
+#define AI_FAINT_THRESHOLD_PESSIMISTIC 0
+#define AI_FAINT_THRESHOLD_RANDOM      1
+#define AI_FAINT_THRESHOLD_OPTIMISTIC  2
+
 #define AI_LAST_EFFECT_BY_TARGET 0xFF
 
 // get_possible_categories_of_foes_attacks


### PR DESCRIPTION
Now the AI can check whether a move is guaranteed to result in an OHKO and whether a move has any chance to result in an OHKO. These can be done through the macros `if_will_faint` and `if_has_some_chance_to_faint`, respectively, which are used as the macro `if_can_faint`, which works exactly as before.