### PR TITLE
AI: check for 0xFFFF

### DIFF
--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -3524,10 +3524,14 @@ static void Cmd_if_next_turn_target_might_use_move_with_effect(void)
     u8 effect = *(gAIScriptPtr + 1);
     bool8 allMovesKnown = TRUE; // se cambiará a FALSE si no es cierto
 
-    if (effect == AI_LAST_EFFECT_BY_TARGET)
-        effect = gBattleMoves[gLastMoves[gBattlerTarget]].effect;
-
     gAIScriptPtr += 6; // será sobreescrito si el objetivo sí podrá usar un movimiento con el efecto
+
+    if (effect == AI_LAST_EFFECT_BY_TARGET)
+    {
+        if (gLastMoves[gBattlerTarget] == MOVE_NONE || gLastMoves[gBattlerTarget] == 0xFFFF)
+            return;
+        effect = gBattleMoves[gLastMoves[gBattlerTarget]].effect;
+    }
 
     if (gBattleMons[gBattlerTarget].status2 & STATUS2_RECHARGE)
         return; // estará descansando por Hiperrayo o similar

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1241,7 +1241,7 @@ u8 FilterSwitchInsThatMightGetKOedBeforeEndOfTurn(struct Pokemon *party, s32 fir
     u8 moveLimitations;
     s32 i;
 
-    if (!HasYetToAttack(opposingBattler) || move == MOVE_NONE || gBattleMoves[move].power == 0 || gDisableStructs[gActiveBattler].isFirstTurn != 0)
+    if (!HasYetToAttack(opposingBattler) || move == MOVE_NONE || move == 0xFFFF || gBattleMoves[move].power == 0 || gDisableStructs[gActiveBattler].isFirstTurn != 0)
         return filteredMons;
 
     // Comprueba que el rival seguir usando el movimiento


### PR DESCRIPTION
The code now checks that the _move_ stored at some entry in gLastMoves is actually `0xFFFF` before checking its effect, which could make the game read where it should not.