### PR TITLE
AI: change the usage of GetMostSuitableMonToSwitchInto

### DIFF
--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -16,4 +16,9 @@ u8 GetMostSuitableMonToSwitchInto(u8 howTolerableIsNotChanging);
 bool8 AreAttackingStatsLowered(u8 category);
 bool8 IsAccuracyLowered(s8 threshold);
 
+// arguments for GetMostSuitableMonToSwitchInto
+#define NOT_CHANGING_IS_IMPOSSIBLE 0
+#define NOT_CHANGING_IS_UNACCEPTABLE 1
+#define NOT_CHANGING_IS_ACCEPTABLE 2
+
 #endif // GUARD_BATTLE_AI_SWITCH_ITEMS_H

--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -12,10 +12,7 @@ enum
 };
 
 void AI_TrySwitchOrUseItem(void);
-u8 GetMostSuitableMonToSwitchInto(bool8 notChangingIsPossible, bool8 notChangingIsAcceptable);
-u8 GetMostSuitableMonToSwitchInto_NotChangingIsImpossible(void);
-u8 GetMostSuitableMonToSwitchInto_NotChangingIsUnacceptable(void);
-u8 GetMostSuitableMonToSwitchInto_NotChangingIsAcceptable(void);
+u8 GetMostSuitableMonToSwitchInto(u8 howTolerableIsNotChanging);
 bool8 AreAttackingStatsLowered(u8 category);
 bool8 IsAccuracyLowered(s8 threshold);
 

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -71,6 +71,11 @@
 #define AI_UNKNOWN_CATEGORIES_PROBABLY_SPECIAL 7
 #define AI_NO_DAMAGING_MOVES 8
 
+// arguments for GetMostSuitableMonToSwitchInto
+#define NOT_CHANGING_IS_IMPOSSIBLE 0
+#define NOT_CHANGING_IS_UNACCEPTABLE 1
+#define NOT_CHANGING_IS_ACCEPTABLE 2
+
 // script's table id to bit
 #define AI_SCRIPT_CHECK_BAD_MOVE (1 << 0)
 #define AI_SCRIPT_TRY_TO_FAINT (1 << 1)

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -71,11 +71,6 @@
 #define AI_UNKNOWN_CATEGORIES_PROBABLY_SPECIAL 7
 #define AI_NO_DAMAGING_MOVES 8
 
-// arguments for GetMostSuitableMonToSwitchInto
-#define NOT_CHANGING_IS_IMPOSSIBLE 0
-#define NOT_CHANGING_IS_UNACCEPTABLE 1
-#define NOT_CHANGING_IS_ACCEPTABLE 2
-
 // script's table id to bit
 #define AI_SCRIPT_CHECK_BAD_MOVE (1 << 0)
 #define AI_SCRIPT_TRY_TO_FAINT (1 << 1)

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -8,7 +8,6 @@
 #include "random.h"
 #include "util.h"
 #include "constants/abilities.h"
-#include "constants/battle_ai.h"
 #include "constants/item_effects.h"
 #include "constants/items.h"
 #include "constants/moves.h"

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -8,6 +8,7 @@
 #include "random.h"
 #include "util.h"
 #include "constants/abilities.h"
+#include "constants/battle_ai.h"
 #include "constants/item_effects.h"
 #include "constants/items.h"
 #include "constants/moves.h"
@@ -738,7 +739,7 @@ void AI_TrySwitchOrUseItem(void)
         {
             if (*(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) == PARTY_SIZE)
             {
-                s32 monToSwitchId = GetMostSuitableMonToSwitchInto_NotChangingIsUnacceptable();
+                s32 monToSwitchId = GetMostSuitableMonToSwitchInto(NOT_CHANGING_IS_UNACCEPTABLE);
                 if (monToSwitchId == PARTY_SIZE)
                 {
                     if (!(gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
@@ -1835,22 +1836,8 @@ u8 FilterKOsInLessHits(struct Pokemon *party, s32 firstId, s32 lastId, u8 filter
     return filteredMons;
 }
 
-u8 GetMostSuitableMonToSwitchInto_NotChangingIsImpossible(void)
-{
-    return GetMostSuitableMonToSwitchInto(FALSE, FALSE);
-}
 
-u8 GetMostSuitableMonToSwitchInto_NotChangingIsUnacceptable(void)
-{
-    return GetMostSuitableMonToSwitchInto(TRUE, FALSE);
-}
-
-u8 GetMostSuitableMonToSwitchInto_NotChangingIsAcceptable(void)
-{
-    return GetMostSuitableMonToSwitchInto(TRUE, TRUE);
-}
-	
-u8 GetMostSuitableMonToSwitchInto(bool8 notChangingIsPossible, bool8 notChangingIsAcceptable)
+u8 GetMostSuitableMonToSwitchInto(bool8 howTolerableIsNotChanging)
 {
     u8 opposingBattler;
 	s32 bestDmg;
@@ -1863,6 +1850,9 @@ u8 GetMostSuitableMonToSwitchInto(bool8 notChangingIsPossible, bool8 notChanging
     u8 invalidMons;
     u8 filteredMons, newFilteredMons;
     u16 move;
+
+    bool8 notChangingIsPossible = howTolerableIsNotChanging != NOT_CHANGING_IS_IMPOSSIBLE;
+    bool8 notChangingIsAcceptable = howTolerableIsNotChanging == NOT_CHANGING_IS_ACCEPTABLE;
 
     if (*(gBattleStruct->monToSwitchIntoId + gActiveBattler) != PARTY_SIZE)
         return *(gBattleStruct->monToSwitchIntoId + gActiveBattler);

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1605,7 +1605,7 @@ static void OpponentHandleChoosePokemon(void)
 
     if (*(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) == PARTY_SIZE)
     {
-        chosenMonId = GetMostSuitableMonToSwitchInto_NotChangingIsImpossible();
+        chosenMonId = GetMostSuitableMonToSwitchInto(NOT_CHANGING_IS_IMPOSSIBLE);
 
         if (chosenMonId == PARTY_SIZE)
         {

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -1534,7 +1534,7 @@ static void PlayerPartnerHandleChooseItem(void)
 
 static void PlayerPartnerHandleChoosePokemon(void)
 {
-    s32 chosenMonId = GetMostSuitableMonToSwitchInto_NotChangingIsImpossible();
+    s32 chosenMonId = GetMostSuitableMonToSwitchInto(NOT_CHANGING_IS_IMPOSSIBLE);
 
     if (chosenMonId == 6) // just switch to the next mon
     {


### PR DESCRIPTION
The code is now more readable and easier to change. In addition, a macro has been added in battle_ai_script_commands.c which uses the new declaration of GetMostSuitableMonToSwitchInto and gives a more readable code which is also easier to change (and it will change).