### PR TITLE
AI: do not forget the suitable mon found when considering switching out

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -193,7 +193,6 @@ struct AI_ThinkingStruct
     u8 aiLogicId;
     u8 filler12[6];
     u8 simulatedRNG[MAX_MON_MOVES];
-	bool8 switchMon; // Because all available moves have no/little effect.
 };
 
 struct UsedMoves

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -52,11 +52,12 @@
 #define NOT_EXPECTED_TO_SLEEP_DURING_NEXT_TURN(battlerId) (!(gBattleMons[battlerId].status1 & STATUS1_SLEEP) || (gBattleMons[battlerId].status1 & STATUS1_SLEEP) == 5)
 #define EXPECTED_TO_SLEEP_DURING_NEXT_TURN(battlerId) (!NOT_EXPECTED_TO_SLEEP_DURING_NEXT_TURN(battlerId))
 
-#define SWITCH_IF_THERE_IS_A_SUITABLE_MON(criterion) {           \
-    if (GetMostSuitableMonToSwitchInto(criterion) != PARTY_SIZE) \
-    {                                                            \
-        AI_THINKING_STRUCT->switchMon = TRUE;                    \
-        return AI_CHOICE_SWITCH;                                 \
+#define SWITCH_IF_THERE_IS_A_SUITABLE_MON(criterion) {                       \
+    u8 bestMonFound = GetMostSuitableMonToSwitchInto(criterion);             \
+    if (bestMonFound != PARTY_SIZE)                                          \
+    {                                                                        \
+        *(gBattleStruct->AI_monToSwitchIntoId + sBattler_AI) = bestMonFound; \
+        return AI_CHOICE_SWITCH;                                             \
     }}
 
 // AI states

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -22,19 +22,17 @@ static bool8 HasSuperEffectiveMoveAgainstOpponents(bool8 noRng);
 static bool8 FindMonWithFlagsAndSuperEffective(u8 flags, u8 moduloPercent);
 static bool8 ShouldUseItem(void);
 
-static bool8 ShouldSwitchIfAllBadMoves(void)
+// Determina si la IA decidió un cambio tras evaluar los movimientos disponibles
+// (criterios de cambio en battle_ai_script_commands.c)
+static bool8 ASwitchWasDecidedAfterConsideringAvailableMoves(void)
 {
-    if (gBattleResources->ai->switchMon)
+    if (*(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) != PARTY_SIZE)
     {
-        gBattleResources->ai->switchMon = 0;
-        *(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) = PARTY_SIZE;
         BtlController_EmitTwoReturnValues(1, B_ACTION_SWITCH, 0);
         return TRUE;
     }
     else
-    {
         return FALSE;
-    }
 }
 
 static bool8 ShouldSwitchIfForcedToUseStruggle(void)
@@ -692,15 +690,20 @@ static bool8 ShouldSwitch(void)
 
     if (availableToSwitch == 0)
         return FALSE;
-	 if (ShouldSwitchIfAllBadMoves())
+
+    // Si se decidió un cambio tras evaluar los movimientos, se marcará y se hará ahora
+    // (usando los criterios de battle_ai_script_commands.c)
+    if (ASwitchWasDecidedAfterConsideringAvailableMoves())
         return TRUE;
+
+    // Los siguientes criterios se evalúan antes que los movimientos disponibles
     if (ShouldSwitchIfPerishSong())
+        return TRUE;
+    if (ShouldSwitchIfForcedToUseStruggle())
         return TRUE;
 	if (HasMove(MOVE_BATON_PASS))
         return FALSE; // los supuestos de cambio a continuación aplican igual con Baton Pass, por lo que el cambio es mejor con Baton Pass
     if (ShouldSwitchIfWonderGuard())
-        return TRUE;
-    if (ShouldSwitchIfForcedToUseStruggle())
         return TRUE;
 /*    if (FindMonThatAbsorbsOpponentsMove())
         return TRUE; */


### PR DESCRIPTION
Commit 556f00d7940 added a way for the AI to switch out when all the moves had a low score, which comes itself from DizzyEggg/pokeemerald@272fa07799. It has been a really long way from this, and now the AI takes advantage of this for many other criteria for switching out after evaluating the moves, choosing suitable mons with different criteria depending on the situation. This has been possible thanks to that.

However, there is a small problem. The way commit DizzyEggg/pokeemerald@272fa07799 is designed, the most suitable mon found is completely ignored. The most suitable mon has to be chosen again in `AI_TrySwitchOrUseItem`. Note that it is not stored after calling `GetMostSuitableMonToSwitchInto` in `battle_ai_script_commands.c`; only the fact that there were more than zero suitable mons is stored in `switchMon`.

In addition to a waste of CPU, this can affect our current criteria for switching out, as they depend on the direness of the situation, and `AI_TrySwitchOrUseItem` always considers that not changing is _unacceptable_. It mostly does not, as the criteria are similar except some discard mons in not too bad situations while in other cases the criteria cannot discard all mons (e.g. when not changing is impossible), but maybe it will in the future.

In addition, if the AI somehow controls the player too (yes, I have been testing that 👀), the value in `switchMon` can be overwritten before the time the AI reconsiders if it has to switch out (it is for example unset when starting to give scores to the moves). This can force the AI to recalculate _everything_, including evaluating the attacks. This does not lead to a loop, as at least one of the AIs gets it right, but it is even more wasteful. In addition, this could be a problem should we allow the AI of the player's partner to consider switching out (however, double battles are currently pretty much ignored throughout the AI).

The solution is to actually use a field in `gBattleStruct` which fits this purpose. It is preserved between AI evaluation steps (unlike `AI_THINKING_STRUCT`) but is unset before the beginning of the turn, and it has an entry for each of the up to 4 mons in the field.

In addition, a small rearrangement of the criteria for switching out has been done, and the function of checking if a switching was decided has been renamed in order to not suggest that there are no more criteria than the one of switching out because of bad scores in the moves.