### PR TITLE
AI: rework IsTruantMonVulnerable

### DIFF
--- a/include/battle_ai_script_commands.h
+++ b/include/battle_ai_script_commands.h
@@ -21,7 +21,7 @@ void ClearBattlerItemEffectHistory(u8 battlerId);
 void AI_MarkForcedChange(void);
 
 bool32 OurShedinjaIsVulnerable(u32 battlerAI, u32 opposingBattler, u16 consideredMove);
-bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler);
+bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler, bool8 opposingBattlerHasToAttackAfterSwitchin);
 s32 CalculateNHKO(u16 attackerId, u16 targetId, bool8 attackerIsCurrentAI, u16 consideredMove, bool8 assumeWorstCaseScenario, bool8 ignoreFocusPunch);
 
 #endif // GUARD_BATTLE_AI_SCRIPT_COMMANDS_H

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -491,20 +491,63 @@ u8 BattleAI_ChooseMoveOrAction(void)
     return ret;
 }
 
-bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler)
+bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler, bool8 opposingBattlerHasToAttackAfterSwitchin)
 {
     s32 i;
 
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         u32 move = FOES_MOVE_HISTORY(opposingBattler)[i];
-        if (gBattleMoves[move].effect == EFFECT_PROTECT)
-            return TRUE;
-		if (gBattleMoves[move].effect == EFFECT_SUBSTITUTE
-			&& gBattleMons[opposingBattler].hp > gBattleMons[opposingBattler].maxHP / 4) // tiene PS para meter sub
-            return TRUE;
-		 if (gBattleMoves[move].effect == EFFECT_SEMI_INVULNERABLE && GetWhoStrikesFirst(battlerAI, opposingBattler, TRUE) == 1)
-            return TRUE;
+
+        switch(gBattleMoves[move].effect)
+        {
+            case EFFECT_PROTECT:
+                return TRUE;
+            case EFFECT_SUBSTITUTE:
+                if (gBattleMons[opposingBattler].hp > gBattleMons[opposingBattler].maxHP / 4) // tiene PS para meter sub
+                    return TRUE;
+                break;
+            case EFFECT_SEMI_INVULNERABLE:
+                /*
+                  Hay cuatro factores a tener en cuenta:
+                   - A: Si el poke de la IA es más lento.
+                   - B: Si el rival ya está en una etapa semiinvulnerable en este momento.
+                   - C: Si en el próximo ataque toca holgazanear.
+                   - D: Si el rival tendrá un turno más para atacar (por estar considerando un cambio).
+                  
+                  C y D no pueden darse a la vez.
+                  
+                  La lógica seguida es la siguiente:
+                   - B, C, D falsos. En este caso, el poke con Truant será frenado si es más lento, pero podrá atacar si no.
+                   - C, D falsos, B verdadero. Se le da la vuelta al anterior escenario si el rival está en una etapa semiinvulnerable: el poke con Truant podrá atacar (aguantando un golpe) si es más lento, pero será bloqueado si es más rápido.
+                   - D falso, C verdadero: si B es falso, el rival puede aprovechar la ventaja que tiene para ponerse en el escenario que le interese (usando el movimiento de semiinvulnerabilidad si el poke de la IA es más lento, no usándolo ahora sino en el siguiente turno si es más rápido), mientras que si es verdadero es como el caso con B, C, D falsos.
+                   - D verdadero (C falso), ...:
+                       + B verdadero. Entonces al siguiente turno será como el caso con B, C, D falso.
+                       + B falso. Si el rival no tira el mov de semiinvulnerabilidad en el cambio, entonces es como el escenario con B, C, D falso. Si lo hace, entonces es al revés. Haremos que la IA asuma que no lo hace: si sí lo hace y no conviene puede rectificar al siguiente turno (además la IA podrá escoger un poke que aguante bien el golpe si lo hay), pero si asume lo contrario y no lo hace puede ser menos cómodo rectificar.
+
+                   El siguiente código recorre estos escenarios en orden inverso.
+                */
+                #define TRUANT_MON_IS_SLOWER (GetWhoStrikesFirst(battlerAI, opposingBattler, TRUE) == 1)
+                if (opposingBattlerHasToAttackAfterSwitchin) // D
+                { // Si D, entonces el poke con Truant corre peligro cuando es más lento
+                    if (TRUANT_MON_IS_SLOWER)
+                        return TRUE;
+                }
+                else if (gDisableStructs[battlerAI].truantCounter) // C
+                { // Si C y no D, el poke con Truant corre peligro excepto si es más rápido y el rival está en una etapa semiinvulnerable
+                    if (!(gStatuses3[opposingBattler] & STATUS3_SEMI_INVULNERABLE) || TRUANT_MON_IS_SLOWER)
+                        return TRUE;
+                }
+                else if (gStatuses3[opposingBattler] & STATUS3_SEMI_INVULNERABLE) // B
+                { // Si B, no C y no D, corre peligro si es más rápido
+                    if (!TRUANT_MON_IS_SLOWER)
+                        return TRUE;
+                }
+                else if (TRUANT_MON_IS_SLOWER) // A
+                    return TRUE; // corre peligro si es más lento
+                #undef TRUANT_MON_IS_SLOWER
+                break;
+        }
     }
     return FALSE;
 }
@@ -874,15 +917,17 @@ static u8 ChooseMoveOrAction_Singles(void)
     }
 #endif
 
-	   // Consider switching if your mon with truant is bodied by Protect spam.
-        // Or is using a double turn semi invulnerable move(such as Fly) and is faster.
+        // Consider switching if your mon with truant is bodied by Protect spam.
+        // Or can be exploited by semi invulnerable moves (such as Fly).
         // Or its ability is actually not Truant.
 		if (gBattleMons[sBattler_AI].ability == ABILITY_TRUANT
-            && (GetAbilityBySpecies(gBattleMons[sBattler_AI].species, gBattleMons[sBattler_AI].abilityNum) != ABILITY_TRUANT
-            || IsTruantMonVulnerable(sBattler_AI, gBattlerTarget))
-            && gDisableStructs[sBattler_AI].truantCounter
+            && (IsTruantMonVulnerable(sBattler_AI, gBattlerTarget, FALSE)
+                || (GetAbilityBySpecies(gBattleMons[sBattler_AI].species, gBattleMons[sBattler_AI].abilityNum) != ABILITY_TRUANT
+                  && gDisableStructs[sBattler_AI].truantCounter
+                   )
+               )
 			&& AICanSwitchAssumingEnoughPokemon())
-            SWITCH_IF_THERE_IS_A_SUITABLE_MON(NOT_CHANGING_IS_UNACCEPTABLE);
+            SWITCH_IF_THERE_IS_A_SUITABLE_MON(gDisableStructs[sBattler_AI].truantCounter ? NOT_CHANGING_IS_UNACCEPTABLE : NOT_CHANGING_IS_ACCEPTABLE);
 
 
 // Consider switching if all moves are worthless to use.
@@ -1002,10 +1047,14 @@ static u8 ChooseMoveOrAction_Singles(void)
                   && !(nhko_taken == 1 && gBattleMoves[move].priority < 0)); // sí, Focus Punch tiene -3
             u8 attacks_until_ko = nhko_taken - (ai_is_faster ? 0 : 1);
 
+            if ((gStatuses3[sBattler_AI] & STATUS3_PERISH_SONG) && gDisableStructs[sBattler_AI].perishSongTimer + 1 < attacks_until_ko)
+                attacks_until_ko = 1 + gDisableStructs[sBattler_AI].perishSongTimer;
+
+            if (gBattleMons[sBattler_AI].ability == ABILITY_TRUANT)
+                attacks_until_ko = (attacks_until_ko + (gDisableStructs[sBattler_AI].truantCounter ? 0 : 1))/2;
+
             if (attacks_until_ko > 1 && gBattleMoves[move].effect == EFFECT_EXPLOSION)
                 attacks_until_ko = 1;
-            else if ((gStatuses3[sBattler_AI] & STATUS3_PERISH_SONG) && gDisableStructs[sBattler_AI].perishSongTimer + 1 < attacks_until_ko)
-                attacks_until_ko = 1 + gDisableStructs[sBattler_AI].perishSongTimer;
 
             if (attacks_until_ko > 1 && (gStatuses3[sBattler_AI] & STATUS3_YAWN))
                 attacks_until_ko -= 1; // probablemente más
@@ -1091,7 +1140,14 @@ static u8 ChooseMoveOrAction_Singles(void)
         // la IA mira si puede hacer un buen cambio en lugar de atacar
         if (gBattleMons[sBattler_AI].ability == ABILITY_TRUANT
             && gDisableStructs[sBattler_AI].truantCounter
-            && currentMoveArray[0] < 103 // el movimiento elegido no es muy bueno
+            && (currentMoveArray[0] < 103 || gBattleMons[gBattlerTarget].status2 & STATUS2_SUBSTITUTE) // el movimiento elegido no es muy bueno o el rival tiene un sustituto
+            && !( // no tiene Evasión subida vs un rival intoxicado o maldito
+                 gBattleMons[sBattler_AI].statStages[STAT_EVASION] >= 10 // +4 o más
+                 && ((gBattleMons[gBattlerTarget].status1 & STATUS1_TOXIC_POISON) || (gBattleMons[gBattlerTarget].status2 & STATUS2_CURSED))
+                )
+            && !( // no pasa a la vez: tener sub, que el rival esté recargando (Hyper Beam...) y ser más rápido
+                 (gBattleMons[sBattler_AI].status2 & STATUS2_SUBSTITUTE) && (gBattleMons[gBattlerTarget].status2 & STATUS2_RECHARGE) && GetWhoStrikesFirst(sBattler_AI, gBattlerTarget, TRUE) == 0
+                )
             && AICanSwitchAssumingEnoughPokemon()
            )
                 SWITCH_IF_THERE_IS_A_SUITABLE_MON(NOT_CHANGING_IS_ACCEPTABLE);
@@ -1330,18 +1386,21 @@ static u8 ChooseMoveOrAction_Doubles(void)
     gBattlerTarget = mostViableTargetsArray[Random() % mostViableTargetsNo];
 
     // Consider switching if your mon with truant is bodied by Protect spam.
-    // Or is using a double turn semi invulnerable move(such as Fly) and is faster.
+    // Or can be exploited by semi invulnerable moves (such as Fly).
     // Or its ability is actually not Truant.
     if (gBattleMons[sBattler_AI].ability == ABILITY_TRUANT
         && GET_BATTLER_SIDE(sBattler_AI) != GET_BATTLER_SIDE(gBattlerTarget)
         && actionOrMoveIndex[gBattlerTarget] != AI_CHOICE_FLEE
         && actionOrMoveIndex[gBattlerTarget] != AI_CHOICE_WATCH
-        && (GetAbilityBySpecies(gBattleMons[sBattler_AI].species, gBattleMons[sBattler_AI].abilityNum) != ABILITY_TRUANT
-              || (IsTruantMonVulnerable(sBattler_AI, gBattlerTarget)
-                  && (gBattleMons[gBattlerTarget ^ BIT_FLANK].hp == 0 || IsTruantMonVulnerable(sBattler_AI, gBattlerTarget ^ BIT_FLANK))))
-        && gDisableStructs[sBattler_AI].truantCounter
+        && ((IsTruantMonVulnerable(sBattler_AI, gBattlerTarget, FALSE)
+            && (gBattleMons[gBattlerTarget ^ BIT_FLANK].hp == 0 || IsTruantMonVulnerable(sBattler_AI, gBattlerTarget ^ BIT_FLANK, FALSE)) // no puede atacar al otro porque no hay otro o por lo mismo
+            )
+            || (GetAbilityBySpecies(gBattleMons[sBattler_AI].species, gBattleMons[sBattler_AI].abilityNum) != ABILITY_TRUANT
+              && gDisableStructs[sBattler_AI].truantCounter
+               )
+           )
         && AICanSwitchAssumingEnoughPokemon())
-        SWITCH_IF_THERE_IS_A_SUITABLE_MON(NOT_CHANGING_IS_UNACCEPTABLE);
+        SWITCH_IF_THERE_IS_A_SUITABLE_MON(gDisableStructs[sBattler_AI].truantCounter ? NOT_CHANGING_IS_UNACCEPTABLE : NOT_CHANGING_IS_ACCEPTABLE);
     return actionOrMoveIndex[gBattlerTarget];
 }
 

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -499,7 +499,13 @@ bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler, bool8 opposingB
     {
         u32 move = FOES_MOVE_HISTORY(opposingBattler)[i];
 
-        if ((gBattleMons[opposingBattler].status2 & (STATUS2_RECHARGE | STATUS2_MULTIPLETURNS) || (gDisableStructs[opposingBattler].encoreTimer && gDisableStructs[opposingBattler].encoredMove != move))
+        if (
+            (
+             (gBattleMons[opposingBattler].status2 & (STATUS2_RECHARGE | STATUS2_MULTIPLETURNS) && !(gStatuses3[opposingBattler] & STATUS3_SEMI_INVULNERABLE && gBattleMoves[move].effect == EFFECT_SEMI_INVULNERABLE)
+             ) 
+             || 
+             (gDisableStructs[opposingBattler].encoreTimer && gDisableStructs[opposingBattler].encoredMove != move)
+            )
             && !gDisableStructs[battlerAI].truantCounter
             && !opposingBattlerHasToAttackAfterSwitchin
            )

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -499,14 +499,35 @@ bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler, bool8 opposingB
     {
         u32 move = FOES_MOVE_HISTORY(opposingBattler)[i];
 
+        if ((gBattleMons[opposingBattler].status2 & (STATUS2_RECHARGE | STATUS2_MULTIPLETURNS) || (gDisableStructs[opposingBattler].encoreTimer && gDisableStructs[opposingBattler].encoredMove != move))
+            && !gDisableStructs[battlerAI].truantCounter
+            && !opposingBattlerHasToAttackAfterSwitchin
+           )
+            continue; // si el rival está ocupado con otro movimiento y no toca holgazanear, no nos preocupa de momento que el rival tenga este movimiento
+
         switch(gBattleMoves[move].effect)
         {
-            case EFFECT_PROTECT:
-                return TRUE;
             case EFFECT_SUBSTITUTE:
-                if (gBattleMons[opposingBattler].hp > gBattleMons[opposingBattler].maxHP / 4) // tiene PS para meter sub
-                    return TRUE;
-                break;
+                if (gBattleMons[opposingBattler].hp <= gBattleMons[opposingBattler].maxHP / 4)
+                    break; // si no tiene PS para meter sub, no nos preocupa
+
+                if (GetWhoStrikesFirst(battlerAI, opposingBattler, TRUE) == 0
+                    && !gDisableStructs[battlerAI].truantCounter
+                    && !opposingBattlerHasToAttackAfterSwitchin
+                   )
+                    break; // si nos da tiempo a atacar antes de que ponga sub, no nos preocupa por el momento
+
+                return TRUE;
+
+            case EFFECT_PROTECT:
+                if ((gLastResultingMoves[opposingBattler] == MOVE_PROTECT || gLastResultingMoves[opposingBattler] == MOVE_DETECT || gLastResultingMoves[opposingBattler] == MOVE_ENDURE)
+                    && gDisableStructs[opposingBattler].protectUses >= 2
+                    && !gDisableStructs[battlerAI].truantCounter
+                    && !opposingBattlerHasToAttackAfterSwitchin)
+                    break; // si el rival se protegió dos o más veces seguidas, se la juega a que la próxima probablemente falle
+
+                return TRUE;
+
             case EFFECT_SEMI_INVULNERABLE:
                 /*
                   Hay cuatro factores a tener en cuenta:

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1445,38 +1445,25 @@ u8 FilterTruantIfUseless(struct Pokemon *party, s32 firstId, s32 lastId, u8 filt
         }
     if (truantMons)
     {
-        if (!HasYetToAttack(opposingBattler))
-        {
-            struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
-			struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
-            u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
-            const u32 newStatus2 = (gCurrentMove == MOVE_BATON_PASS ? (currentMon.status2 & STATUS2_KEPT_BY_SUBSTITUTE) : 0);
-			for (i = firstId; i < lastId; i++)
-                if ((gBitTable[i] & truantMons))
-                {
-                    PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
-                    gBattleMons[gActiveBattler].status2 = newStatus2;
-                    gBattlerPartyIndexes[gActiveBattler] = i;
-					PrepareDisableStructForSwitchIn(gActiveBattler, &disableStructCopy);
+        struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
+        struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+        u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
+        const u32 newStatus2 = (gCurrentMove == MOVE_BATON_PASS ? (currentMon.status2 & STATUS2_KEPT_BY_SUBSTITUTE) : 0);
+        for (i = firstId; i < lastId; i++)
+            if ((gBitTable[i] & truantMons))
+            {
+                PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                gBattleMons[gActiveBattler].status2 = newStatus2;
+                gBattlerPartyIndexes[gActiveBattler] = i;
+                PrepareDisableStructForSwitchIn(gActiveBattler, &disableStructCopy);
 
-                    if (IsTruantMonVulnerable(gActiveBattler, opposingBattler))
-                        vulnerableTruantMons |= gBitTable[i];
-                }
-            
-            gBattleMons[gActiveBattler] = currentMon;
-			gDisableStructs[gActiveBattler] = disableStructCopy;
-            gBattlerPartyIndexes[gActiveBattler] = partyIndex;
-        }
-        else // Si el rival no ha atacado, podría anticiparse aunque sea más lento
-        {
-            u16 currentSpeed = gBattleMons[gActiveBattler].speed;
-            gBattleMons[gActiveBattler].speed = 0;
-
-            if (IsTruantMonVulnerable(gActiveBattler, opposingBattler))
-                vulnerableTruantMons = truantMons;
-            
-            gBattleMons[gActiveBattler].speed = currentSpeed;
-        }
+                if (IsTruantMonVulnerable(gActiveBattler, opposingBattler, HasYetToAttack(opposingBattler)))
+                    vulnerableTruantMons |= gBitTable[i];
+            }
+        
+        gBattleMons[gActiveBattler] = currentMon;
+        gDisableStructs[gActiveBattler] = disableStructCopy;
+        gBattlerPartyIndexes[gActiveBattler] = partyIndex;
     }
     return (filteredMons | vulnerableTruantMons);
 }


### PR DESCRIPTION
 - If the opponent has two-turn moves, it takes into account who is faster, whether the opponent of the mon with Truant is in a semi-invulnerable stage, whether next turn the Truant mon will loaf around, and whether the opponent has to attack during the current, already started, turn, in order to decide whether the Truant mon can be helpless and a switch is therefore needed.
 - The mon with Truant attempts to switch out even during the turns where it will not loaf around (except if its original ability was not Truant), but choosing a good switchin if available, staying otherwise. This prevents the AI from uselessly attempt to attack mons with Protect, sub, or faster opponents with semi-invulnerability moves.
 - The mon with Truant will not fear moves different from the one the target is encored with, or the multi-turn one it is executing, or any at all if the target is recharging (e.g. Hyper Beam).
 - The mon with Truant will not fear Protect if it will be the third, or more, in a row, and will not fear Substitute if the target is slower and will be attacked before using sub.
 - Truant is taken into account when considering switching out due to being OHKOed soon and not making enough damage before that. This makes the mon with Truant way more likelier to switch out when not useful. In addition, the criteria around that have been reorganized (Perish Song is now checked before Explosion).
 - A switchout during the loafing turn is no longer performed if the mon with Truant has high Evasion against an intoxicated or cursed mon, or under some other suitable conditions.